### PR TITLE
Fix for tests run though testscript

### DIFF
--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -1,4 +1,4 @@
 import libs = fx-gltf%lib{fx-gltf}
 import libs += catch2%lib{catch2}
 
-exe{driver}: src/{hxx ixx txx cxx}{**} $libs testscript{**}
+exe{driver}: src/{hxx ixx txx cxx}{**} $libs testscript

--- a/tests/basics/testscript
+++ b/tests/basics/testscript
@@ -1,5 +1,4 @@
+
 : Test
-
-ln -s ../data/ ./data/ ;
-
-$* 2>- != 0
+ln -s $src_base/data/ $~/data ;
+$* >- == 0


### PR DESCRIPTION
As discussed, the `testscript{**}` expression will look for files with `*.testscript` name, not `testscript` name, which is why the testscript was actually never run (I realized that when trying to log)

I then fixed the testscript so that it acquire the data directory, then so that it checks that the program ends with 0 and that the output is all in standard output, not in error output.

For me (ubuntu with gcc-11 and clang-12) it's running successfully.